### PR TITLE
Adds menu image for Sampler font/text demo

### DIFF
--- a/Sampler/src/bitmapDemo.c
+++ b/Sampler/src/bitmapDemo.c
@@ -135,9 +135,9 @@ static void drawShapes(BitmapDemo *demo) {
 
     int kittyWidth, kittyHeight;
     int rowBytes;
-    int hasMask;
+    uint8_t *mask;
     uint8_t *data;
-    pd->graphics->getBitmapData(demo->kitty, &kittyWidth, &kittyHeight, &rowBytes, &hasMask, &data);
+    pd->graphics->getBitmapData(demo->kitty, &kittyWidth, &kittyHeight, &rowBytes, &mask, &data);
 
     // really want to print ascii
     // print("kitty width %d  height %d  rowBytes %d  hasMask %d",
@@ -276,15 +276,15 @@ DemoSample *bitmapDemoSample(void) {
     // Dump the kitty image to the console - be sure to show it and embiggen.
     int kittyWidth, kittyHeight;
     int rowBytes;
-    int hasMask;
+    uint8_t *mask;
     uint8_t *data;
-    pd->graphics->getBitmapData(demo->kitty, &kittyWidth, &kittyHeight, &rowBytes, &hasMask, &data);
+    pd->graphics->getBitmapData(demo->kitty, &kittyWidth, &kittyHeight, &rowBytes, &mask, &data);
 
 //    dumpBitmapAsASCII(kittyWidth, kittyHeight, rowBytes, data);
 
-    if (hasMask) {
+    if (mask) {
         print("----");
-//        dumpBitmapAsASCII(kittyWidth, kittyHeight, rowBytes, data + rowBytes * kittyHeight);
+//        dumpBitmapAsASCII(kittyWidth, kittyHeight, rowBytes, mask);
     }
         
 

--- a/Sampler/src/demoSample.c
+++ b/Sampler/src/demoSample.c
@@ -10,6 +10,7 @@ DemoSample *demoSampleNew(const char *name,
     moi->name = name;
     moi->category = category;
     moi->updateCallback = updateCallback;
+    moi->menuImageCallback = NULL;
 
     return moi;
 

--- a/Sampler/src/demoSample.h
+++ b/Sampler/src/demoSample.h
@@ -9,6 +9,11 @@ typedef enum DemoSampleCategory {
     kSynth,
 } DemoSampleCategory;
 
+struct DemoSample;
+
+typedef LCDBitmap *MenuImageCallback(struct DemoSample *sample,
+                                     int *outXOffset /*nullable*/ );
+
 // To use, embed this as the first field of your structure.
 // Then provide a function make one.  Call demoSampleNew to create it,
 // passing sizeof your struct.
@@ -16,6 +21,7 @@ typedef struct DemoSample {
     const char *name;
     DemoSampleCategory category;
     PDCallbackFunction *updateCallback;
+    MenuImageCallback *menuImageCallback;
     // suspend
     // resume
 } DemoSample;

--- a/Sampler/src/fontDemo.c
+++ b/Sampler/src/fontDemo.c
@@ -37,7 +37,6 @@ static void commonInit(DemoView *demoView, const char *menuText) {
 
     const char *errorText = NULL;
     const char *fontpath = "font/Roobert-11-Mono-Condensed";
-    // const char *fontpath = "font/Asheville-Rounded-24-px";
     demoView->menuImageFont = pd->graphics->loadFont(fontpath, &errorText);
     if (demoView->menuImageFont == NULL) {
         print("could not load font %s - %s", fontpath, errorText);
@@ -105,7 +104,8 @@ static void handleButtons(PDButtons buttons, UpDown upDown, void *context) {
 // FPS when wrapping double the pirsig string.
 void drawWrappedString(const char *string,
                        LCDFont *withFont, Rect inRect,
-                       WordWidthHash **wordWidthHash) {
+                       WordWidthHash **wordWidthHash,
+                       int newlineLeading) {
     pd->graphics->setFont(withFont);
 
     int lineLength = 0;
@@ -161,7 +161,7 @@ void drawWrappedString(const char *string,
 
             if (*scan == '\n') {
                 x = inRect.x;
-                y += fontHeight;
+                y += fontHeight + newlineLeading;
                 lineLength = 0;
             }
 
@@ -175,6 +175,7 @@ void drawWrappedString(const char *string,
     }
 
 } // drawWrappedString
+
 
 static LCDBitmap *menuImageCallback(DemoSample *sample, int *outXOffset) {
     FontDemo *fontDemo = (FontDemo *)sample;
@@ -193,7 +194,8 @@ static LCDBitmap *menuImageCallback(DemoSample *sample, int *outXOffset) {
             fillRect(rect, kColorWhite);
             drawWrappedString(demoView->menuText,
                               demoView->menuImageFont, insetRect,
-                              &demoView->menuImageWordWidthHash);
+                              &demoView->menuImageWordWidthHash,
+                              6);
 
         } pd->graphics->popContext();
     }
@@ -279,7 +281,10 @@ typedef struct MarkdownDemoView {
 
 DemoView *fontMakeMarkdownDemoView(void) {
     static MarkdownDemoView view;
-    const char *menuText = "MarkDown";
+    const char *menuText = "MARKDOWN DEMO\n"
+        "* So far just optimistic comments\n"
+        "* Left/Right to change Text Tabs";
+
     commonInit(&view.isa, menuText);
 
     view.isa.name = "Markdown Demo";
@@ -349,9 +354,9 @@ static int wrappedDemoUpdate(void *context) {
 
     LCDFont *font = view->fonts[view->currentFontIndex];
     drawWrappedString(wrappedText, font, wrapFrame,
-                      &view->wordWidthHashes[view->currentFontIndex]);
+                      &view->wordWidthHashes[view->currentFontIndex], 0);
 //    drawWrappedString(warAndPeace, font, wrapFrame,
-//                      &view->wordWidthHashes[view->currentFontIndex]);
+//                      &view->wordWidthHashes[view->currentFontIndex], 0);
 
     pd->system->drawFPS(30, kScreenHeight - 20);
 
@@ -381,7 +386,11 @@ static void wrappedTextHandleButtons(PDButtons buttons, UpDown upDown, void *con
 
 DemoView *fontMakeWrappedTextDemoView(void) {
     static WrappedDemoView view;
-    const char *menuText = "Wrapped Text";
+    const char *menuText = "WRAPPING DEMO\n"
+        "* Up/Down to change font\n"
+        "* Crank to change wrapping rectangle\n"
+        "* Left/Right to change Text Tabs";
+
     commonInit(&view.isa, menuText);
 
     view.isa.name = "Wrapped Demo";
@@ -641,9 +650,11 @@ static void scrollingDemoHandleButtons(PDButtons buttons, UpDown upDown, void *c
 
 DemoView *fontMakeScrollingTextDemoView(void) {
     static ScrollingDemoView view;
-    const char *menuText = "Scrolling";
+    const char *menuText = "SCROLLING DEMO\n"
+        "* Crank to scroll War and Peace\n"
+        "* Up/Down to scroll by line\n"
+        "* Left/Right to change Text Tabs";
     commonInit(&view.isa, menuText);
-
 
     view.isa.name = "Scrolling Demo";
     view.isa.updateCallback = scrollingDemoViewUpdate;

--- a/Sampler/src/fontDemo.c
+++ b/Sampler/src/fontDemo.c
@@ -18,6 +18,8 @@ typedef struct DemoView {
     const char *name;
     PDCallbackFunction *updateCallback;
     ButtonPumperCallback *buttonCallback;
+    bool isDirty;
+
 } DemoView;
 
 DemoView *fontMakeMarkdownDemoView(void);
@@ -60,8 +62,10 @@ static void handleButtons(PDButtons buttons, UpDown upDown, void *context) {
         if (fd->currentDemoViewIndex < 0) {
             fd->currentDemoViewIndex = count - 1;
         }
+        fd->demoViews[fd->currentDemoViewIndex]->isDirty = true;
     } else if (buttons == kButtonRight && upDown == kPressed) {
         fd->currentDemoViewIndex = (fd->currentDemoViewIndex + 1) % count;
+        fd->demoViews[fd->currentDemoViewIndex]->isDirty = true;
     } else {
         DemoView *currentDemoView = fd->demoViews[fd->currentDemoViewIndex];
 
@@ -69,6 +73,7 @@ static void handleButtons(PDButtons buttons, UpDown upDown, void *context) {
             currentDemoView->buttonCallback(buttons, upDown, currentDemoView);
         }
     }
+    print("CURRENT INDEX IS %d", fd->currentDemoViewIndex);
 } // handleButtons
 
 
@@ -394,8 +399,6 @@ DemoView *fontMakeWrappedTextDemoView(void) {
 typedef struct ScrollingDemoView {
     DemoView isa;
 
-    bool isDirty;
-
     const char *warAndPeace;
     WordWidthHash *wordWidthHash;
 
@@ -515,7 +518,7 @@ void drawWrappedStringFromTopLine(const char *string,
 int scrollingDemoViewUpdate(void *userdata) {
     ScrollingDemoView *view = (ScrollingDemoView *)userdata;
 
-    if (!view->isDirty) {
+    if (!view->isa.isDirty) {
         pd->system->drawFPS(30, kScreenHeight - 20);
     }
 
@@ -530,27 +533,27 @@ int scrollingDemoViewUpdate(void *userdata) {
     }
     if (crankValue > 7.0f) {
         view->currentTopLine += 11;
-        view->isDirty = true;
+        view->isa.isDirty = true;
     } else if (crankValue > 3.5f) {
         view->currentTopLine += 5;
-        view->isDirty = true;
+        view->isa.isDirty = true;
     } else if (crankValue > 0.0f) {
         view->currentTopLine += 1;
-        view->isDirty = true;
+        view->isa.isDirty = true;
     } else if (crankValue < -7.0f) {
         view->currentTopLine -= 11;
-        view->isDirty = true;
+        view->isa.isDirty = true;
     } else if (crankValue < -3.5f) {
         view->currentTopLine -= 5;
-        view->isDirty = true;
+        view->isa.isDirty = true;
     } else if (crankValue < 0.0f) {
         view->currentTopLine -= 1;
-        view->isDirty = true;
+        view->isa.isDirty = true;
     }
     view->currentTopLine = MAX(view->currentTopLine, 0);
 
-    if (!view->isDirty) return 1;
-    view->isDirty = false;
+    if (!view->isa.isDirty) return 1;
+    view->isa.isDirty = false;
 
     pd->graphics->clear(kColorWhite);
 
@@ -589,10 +592,10 @@ static void scrollingDemoHandleButtons(PDButtons buttons, UpDown upDown, void *c
         view->currentTopLine--;
         if (view->currentTopLine < 0) view->currentTopLine = 0;
 
-        view->isDirty = true;
+        view->isa.isDirty = true;
     } else if (buttons == kButtonDown) {
         view->currentTopLine++;
-        view->isDirty = true;
+        view->isa.isDirty = true;
     }
     print("%d", view->currentTopLine);
     
@@ -633,7 +636,7 @@ DemoView *fontMakeScrollingTextDemoView(void) {
         print("could not load font %s - %s", fontpath, errorText);
     }
 
-    view.isDirty = true;
+    view.isa.isDirty = true;
 
     return (DemoView *)&view;
 } // fontMakeScrollingTextDemoView

--- a/Sampler/src/fontDemo.c
+++ b/Sampler/src/fontDemo.c
@@ -72,10 +72,32 @@ static void handleButtons(PDButtons buttons, UpDown upDown, void *context) {
 } // handleButtons
 
 
+static LCDBitmap *menuImageBitmap;
+
+static LCDBitmap *menuImageCallback(DemoSample *sample, int *outXOffset) {
+    if (outXOffset != NULL) {
+        *outXOffset = 0;
+    }
+
+    if (menuImageBitmap == NULL) {
+        menuImageBitmap = pd->graphics->newBitmap(kScreenWidth, kScreenHeight, kColorWhite);
+        const int width = 3;
+        pd->graphics->pushContext(menuImageBitmap); {
+            pd->graphics->drawLine(0, 0, kScreenWidth, kScreenHeight, width, kColorBlack);
+            pd->graphics->drawLine(kScreenWidth, 0, 0, kScreenHeight, width, kColorBlack);
+        } pd->graphics->popContext();
+    }
+
+    return menuImageBitmap;
+
+} // menuImageCallback
+
+
 DemoSample *fontDemoSample(void) {
     FontDemo *demo = (FontDemo *)demoSampleNew("Font", kFont,
                                                update,
                                                sizeof(FontDemo));
+    demo->isa.menuImageCallback = menuImageCallback;
     demo->pumper = buttonPumperNew(handleButtons, demo);
 
     demo->currentDemoViewIndex = 2; // start with scrolling text demo

--- a/Sampler/src/fontDemo.c
+++ b/Sampler/src/fontDemo.c
@@ -43,6 +43,10 @@ static void commonInit(DemoView *demoView) {
     }
     sh_new_arena(demoView->menuImageWordWidthHash);
 
+    // Make sure an initial allocation for the hash table is made
+    // before passing it around.
+    shput(demoView->menuImageWordWidthHash, "prime", 0);
+
 } // commonInit
 
 

--- a/Sampler/src/fontDemo.c
+++ b/Sampler/src/fontDemo.c
@@ -25,13 +25,14 @@ typedef struct DemoView {
     LCDBitmap *menuImageBitmap;
     LCDFont *menuImageFont;
     WordWidthHash *menuImageWordWidthHash;
+    const char *menuText;
 } DemoView;
 
 DemoView *fontMakeMarkdownDemoView(void);
 DemoView *fontMakeWrappedTextDemoView(void);
 DemoView *fontMakeScrollingTextDemoView(void);
 
-static void commonInit(DemoView *demoView) {
+static void commonInit(DemoView *demoView, const char *menuText) {
     bzero(demoView, sizeof(*demoView));
 
     const char *errorText = NULL;
@@ -46,6 +47,8 @@ static void commonInit(DemoView *demoView) {
     // Make sure an initial allocation for the hash table is made
     // before passing it around.
     shput(demoView->menuImageWordWidthHash, "prime", 0);
+
+    demoView->menuText = menuText;
 
 } // commonInit
 
@@ -180,17 +183,16 @@ static LCDBitmap *menuImageCallback(DemoSample *sample, int *outXOffset) {
 
     if (demoView->menuImageBitmap == NULL) {
         demoView->menuImageBitmap = pd->graphics->newBitmap(kScreenWidth, kScreenHeight, kColorWhite);
-        const int width = 3;
         Rect rect = (Rect){ kScreenWidth / 2, 0, 
                             kScreenWidth / 2, kScreenHeight };
+        Rect insetRect = rectInset(rect, 10, 10);
         pd->graphics->pushContext(demoView->menuImageBitmap); {
             demoView->isDirty = true;
             demoView->updateCallback(demoView);
 
             fillRect(rect, kColorWhite);
-            const char *text = "SPLUNGE MONKEY\nHoover greeble ni peng ni womm ni bork";
-            drawWrappedString(text,
-                              demoView->menuImageFont, rect,
+            drawWrappedString(demoView->menuText,
+                              demoView->menuImageFont, insetRect,
                               &demoView->menuImageWordWidthHash);
 
         } pd->graphics->popContext();
@@ -206,7 +208,7 @@ static LCDBitmap *menuImageCallback(DemoSample *sample, int *outXOffset) {
 
 
 DemoSample *fontDemoSample(void) {
-    FontDemo *demo = (FontDemo *)demoSampleNew("Font", kFont,
+    FontDemo *demo = (FontDemo *)demoSampleNew("Text", kFont,
                                                update,
                                                sizeof(FontDemo));
     demo->isa.menuImageCallback = menuImageCallback;
@@ -277,7 +279,8 @@ typedef struct MarkdownDemoView {
 
 DemoView *fontMakeMarkdownDemoView(void) {
     static MarkdownDemoView view;
-    commonInit(&view.isa);
+    const char *menuText = "MarkDown";
+    commonInit(&view.isa, menuText);
 
     view.isa.name = "Markdown Demo";
     view.isa.updateCallback = markdownCallback;
@@ -378,7 +381,8 @@ static void wrappedTextHandleButtons(PDButtons buttons, UpDown upDown, void *con
 
 DemoView *fontMakeWrappedTextDemoView(void) {
     static WrappedDemoView view;
-    commonInit(&view.isa);
+    const char *menuText = "Wrapped Text";
+    commonInit(&view.isa, menuText);
 
     view.isa.name = "Wrapped Demo";
     view.isa.updateCallback = wrappedDemoUpdate;
@@ -637,7 +641,9 @@ static void scrollingDemoHandleButtons(PDButtons buttons, UpDown upDown, void *c
 
 DemoView *fontMakeScrollingTextDemoView(void) {
     static ScrollingDemoView view;
-    commonInit(&view.isa);
+    const char *menuText = "Scrolling";
+    commonInit(&view.isa, menuText);
+
 
     view.isa.name = "Scrolling Demo";
     view.isa.updateCallback = scrollingDemoViewUpdate;

--- a/Sampler/src/main.c
+++ b/Sampler/src/main.c
@@ -1,3 +1,4 @@
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -67,6 +68,16 @@ static void setupMenu(void) {
     menuItem = pd->system->addOptionsMenuItem("Demos", options, sampleCount,
                                               menuItemCallback, 
                                               "userdata (unused here)");
+
+    DemoSample *currentSample = allSamples[currentIndex];
+    if (currentSample->menuImageCallback != NULL) {
+        int xOffset = 0;
+        LCDBitmap *menuBitmap = currentSample->menuImageCallback(currentSample,
+                                                                 &xOffset);
+        pd->system->setMenuImage(menuBitmap, 0);
+    } else {
+        pd->system->setMenuImage(NULL, 0);
+    }
     
 } // setupMenu
 

--- a/Sampler/src/main.c
+++ b/Sampler/src/main.c
@@ -74,7 +74,7 @@ static void setupMenu(void) {
         int xOffset = 0;
         LCDBitmap *menuBitmap = currentSample->menuImageCallback(currentSample,
                                                                  &xOffset);
-        pd->system->setMenuImage(menuBitmap, 0);
+        pd->system->setMenuImage(menuBitmap, xOffset);
     } else {
         pd->system->setMenuImage(NULL, 0);
     }

--- a/pdnotes.md
+++ b/pdnotes.md
@@ -728,7 +728,7 @@ getHeadphoneState(int *headphone, int *mic, changeCallback(int headphone, int mi
   - if changeclalback is provided, will be called when the status changes.
     - and audio output will *not* automatically switch - the callback should use
        sound->setOutputsActive
-setOUtputsActive - force audio output to the given outputs (headphone / speaker)
+setOutputsActive - force audio output to the given outputs (headphone / speaker)
    regardless of the headphone status
 
 channels
@@ -752,7 +752,7 @@ addCallbackSource - creates a new
   - takes a channel, audioSource function, context, stereo flag
   - the callback takes a context, int16_t *left / right, length
     - no right if it's a stereo source.
-  - the functino should fill in the buffers.  return 1 to play, or 0 if the source
+  - the function should fill in the buffers.  return 1 to play, or 0 if the source
     is silent through the cycle.
   - caller takes ownership of the allocated source, and should free it
     (I don't understsand why it's talking about memory management here)


### PR DESCRIPTION
Sampler now has a menu image that describes the font/text demo tabs.

https://user-images.githubusercontent.com/609957/177451737-3b5f58e7-8f32-45d8-9873-df192ad8b479.mp4

